### PR TITLE
Add --libraries flag to copy .so to a lib directory

### DIFF
--- a/cargo-tai/src/opts/library.rs
+++ b/cargo-tai/src/opts/library.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct LibraryOptions {
+    /// Libraries to include in the app that the built units link to. Format: `local_path`
+    ///
+    /// Example:
+    ///
+    /// `cargo-tai test -l ./openssl-1.1.1s/libssl.so.1.1
+    #[clap(short, long)]
+    pub libraries: Option<Vec<PathBuf>>,
+}

--- a/cargo-tai/src/opts/mod.rs
+++ b/cargo-tai/src/opts/mod.rs
@@ -9,6 +9,7 @@ pub mod binary;
 pub mod cli;
 pub mod compiler;
 pub mod ios;
+pub mod library;
 pub mod resource;
 
 use self::{
@@ -17,6 +18,7 @@ use self::{
     cli::CliOptions,
     compiler::CompilerOptions,
     ios::IosOptions,
+    library::LibraryOptions,
     resource::ResourceOptions,
 };
 
@@ -39,6 +41,9 @@ pub struct LocalRun {
 
     #[structopt(flatten)]
     compiler: CompilerOptions,
+
+    #[structopt(flatten)]
+    libraries: LibraryOptions,
 
     #[structopt(flatten)]
     resources: ResourceOptions,
@@ -68,6 +73,7 @@ fn from_local_run(command: Command, options: LocalRun) -> opts::Options {
     opts::Options {
         command,
         compiler: options.compiler.into(),
+        libraries: options.libraries.libraries,
         resources: options.resources.resources,
         binary: options.binary.into(),
         android: options.android.into(),

--- a/tai-lib/src/android/bundle.rs
+++ b/tai-lib/src/android/bundle.rs
@@ -7,7 +7,7 @@ use tracing::{debug, instrument};
 
 use crate::{
     common::{
-        bundle::{copy_resources, BuiltBundle},
+        bundle::{copy_libraries, copy_resources, BuiltBundle},
         compiler::BuiltUnit,
     },
     TaiResult,
@@ -17,6 +17,7 @@ use crate::{
 pub fn create_bundle<P: AsRef<Path>>(
     unit: BuiltUnit,
     bundles_root: P,
+    libraries: &Option<Vec<PathBuf>>,
     resources: &Option<Vec<(String, PathBuf)>>,
 ) -> TaiResult<BuiltBundle> {
     let bundle_root = bundles_root
@@ -33,6 +34,10 @@ pub fn create_bundle<P: AsRef<Path>>(
     let to = bundle_root.join(&unit.name);
     copy(&unit.artifact, &to)?;
     debug!("copy {} to {}", &unit.artifact.display(), to.display());
+
+    if let Some(libraries) = libraries {
+        copy_libraries(&bundle_root, libraries)?;
+    }
 
     if let Some(resources) = resources {
         copy_resources(&bundle_root, resources)?;

--- a/tai-lib/src/android/task/create_bundles.rs
+++ b/tai-lib/src/android/task/create_bundles.rs
@@ -11,11 +11,13 @@ pub struct CreateBundles;
 impl Task<Context> for CreateBundles {
     fn run(&self, mut context: Context) -> TaiResult<Context> {
         let built_units = context.remove::<BuiltUnits>().0;
-        let resources = &context.get::<Options>().resources;
+        let options = &context.get::<Options>();
+        let libraries = &options.libraries;
+        let resources = &options.resources;
         let project_meta: &ProjectMetadata = context.get();
 
         let bundles = create_bundles(built_units, &project_meta.tai_target, |unit, root| {
-            create_bundle(unit, root, resources)
+            create_bundle(unit, root, libraries, resources)
         })?;
 
         context.insert(bundles);

--- a/tai-lib/src/common/bundle/bundles.rs
+++ b/tai-lib/src/common/bundle/bundles.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, Error};
+use anyhow::{anyhow, Context, Error};
 use tracing::debug;
 
 use crate::{common::compiler::BuiltUnit, TaiResult};
@@ -21,6 +21,40 @@ pub fn create_bundles(
         .collect::<Result<Vec<_>, Error>>()
         .with_context(|| "Failed to built all bundles".to_string())?;
     Ok(BuiltBundles { bundles })
+}
+
+pub fn copy_libraries<P: AsRef<Path>>(
+    dest_dir: P,
+    libraries: &[PathBuf]
+) -> TaiResult<()> {
+    debug!("copy libraries");
+
+    let lib_root = dest_dir.as_ref().join(tai_util::LIB_DIR_NAME);
+    create_dir_all(&lib_root).with_context(|| {
+        format!(
+            "Failed to create library root {}",
+            lib_root.display()
+        )
+    })?;
+    debug!("create dir: {}", lib_root.display());
+
+    let copied: TaiResult<Vec<()>> = libraries
+        .iter()
+        .map(|local_path| {
+            let file_name =
+                local_path
+                    .file_name()
+                    .ok_or_else(|| anyhow!("Cannot get file name for {}", local_path.display()))?;
+            let remote_path = lib_root.join(file_name);
+            copy(local_path, &remote_path)
+                .with_context(|| format!("Failed to copy library {}", local_path.display()))?;
+            debug!("copy {} to {}", local_path.display(), remote_path.display());
+            Ok(())
+        })
+        .collect();
+    copied?;
+
+    Ok(())
 }
 
 pub fn copy_resources<P: AsRef<Path>>(

--- a/tai-lib/src/common/bundle/mod.rs
+++ b/tai-lib/src/common/bundle/mod.rs
@@ -4,7 +4,7 @@ use crate::common::compiler::BuiltUnit;
 
 mod bundles;
 
-pub use bundles::{copy_resources, create_bundles};
+pub use bundles::{copy_libraries, copy_resources, create_bundles};
 
 #[derive(Debug)]
 pub struct BuiltBundles {

--- a/tai-lib/src/common/opts.rs
+++ b/tai-lib/src/common/opts.rs
@@ -8,6 +8,7 @@ use super::command::Command;
 pub struct Options {
     pub command: Command,
     pub compiler: CompilerOptions,
+    pub libraries: Option<Vec<PathBuf>>,
     pub resources: Option<Vec<(String, PathBuf)>>,
     pub binary: Option<BinaryOptions>,
     pub android: Option<AndroidOptions>,

--- a/tai-util/src/lib.rs
+++ b/tai-util/src/lib.rs
@@ -2,6 +2,7 @@ use std::{env, path::PathBuf};
 
 // cannot use resources https://stackoverflow.com/questions/29271548/code-sign-error-bundle-format-unrecognized-invalid-or-unsuitable
 pub const DATA_DIR_NAME: &str = "test-data";
+pub const LIB_DIR_NAME: &str = "lib";
 
 pub fn resources_file_path(test_data_id: &str) -> PathBuf {
     try_resources_file_path(test_data_id)


### PR DESCRIPTION
Needed this to copy `libssl.so` to the Android simulator as a dependency of `openssl-sys` crate with the following full commandline:

```sh
cargo-tai tests --target x86_64-linux-android --android-api-lvl ${ANDROID_API} --android-ndk ${ANDROID_NDK_HOME} --android-sdk /Users/kronic.deth/Library/Android/sdk --libraries /Users/kronic.deth/Downloads/openssl-1.1.1s/libssl.so.1.1  --libraries /Users/kronic.deth/Downloads/openssl-1.1.1s/libcrypto.so.1.1 --envs LD_LIBRARY_PATH=lib
```